### PR TITLE
Add very simple retry

### DIFF
--- a/mtdata/registry.py
+++ b/mtdata/registry.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import Iterable, NamedTuple, Type, Tuple
 
 from .dataset import FetchResult, Dataset
+from .retry import retry
 from .storage import Storage, StoreResult
 
 RegistryList = Iterable[Tuple[Type[Dataset], Iterable[Type[Storage]]]]
@@ -40,7 +41,7 @@ class Registry:
         """
         for dataset_class, store_classes in self._configs:
             dataset = dataset_class()
-            fetch_result = dataset.fetch()
+            fetch_result = retry(dataset.fetch)
 
             if fetch_result.success:
                 transformer = dataset.transformer

--- a/mtdata/retry.py
+++ b/mtdata/retry.py
@@ -1,0 +1,44 @@
+from time import sleep
+from typing import Protocol, Callable, TypeVar
+
+from .dataset import FetchResult
+
+
+class Result(Protocol):
+    """
+    A generic result that can be checked for success.
+    """
+
+    @property
+    def success(self) -> bool:
+        """
+        Indicates whether the result is a success.
+        """
+        ...
+
+
+TResult = TypeVar("TResult", Result, FetchResult)
+
+
+Operation = Callable[[], TResult]
+
+
+def retry(
+    operation: Operation, attempt_delta: int = 3, max_attempts: int = 3
+) -> TResult:
+    """
+    Retry an operation some number of times with a linear back-off.
+    """
+    attempts = 0
+
+    while True:
+        delay = attempts * attempt_delta
+        sleep(delay)
+
+        result = operation()
+        if result.success:
+            return result
+
+        attempts += 1
+        if attempts >= max_attempts:
+            return result

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,35 @@
+from mtdata.retry import retry
+
+
+class FauxResult:
+    def __init__(self, value: bool):
+        self.value = value
+
+    @property
+    def success(self) -> bool:
+        return self.value
+
+
+class FauxOperation:
+    def __init__(self):
+        self.results = [
+            FauxResult(False),
+            FauxResult(True),
+        ]
+
+    def __call__(self):
+        return self.results.pop(0)
+
+
+def test_retry():
+    op = FauxOperation()
+    result = retry(op, attempt_delta=1)
+    assert result.success
+    assert op.results == []
+
+    op = FauxOperation()
+    op.results.insert(0, FauxResult(False))
+    result = retry(op, attempt_delta=1, max_attempts=2)
+    assert not result.success
+    assert len(op.results) == 1
+    assert op.results[0].success


### PR DESCRIPTION
Add a very simple retry functionality, along with tests. The `retry` function uses linear back-off, which should be fine for what we're doing, particularly because we never want it to take very long.

Fixes #21 